### PR TITLE
fix: don't remove kicked out validators in `ping()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,12 +72,11 @@ impl Contract {
         require!(self.result.is_none(), "Voting has already ended");
         let cur_epoch_height = env::epoch_height();
         if cur_epoch_height != self.last_epoch_height {
-            let votes = std::mem::take(&mut self.votes);
             self.total_voted_stake = 0;
-            for (account_id, _) in votes {
-                let account_current_stake = validator_stake(&account_id);
+            for (account_id, stake) in self.votes.iter_mut() {
+                let account_current_stake = validator_stake(account_id);
                 self.total_voted_stake += account_current_stake;
-                self.votes.insert(account_id, account_current_stake);
+                *stake = account_current_stake;
             }
             self.check_result();
             self.last_epoch_height = cur_epoch_height;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,7 @@ impl Contract {
             for (account_id, _) in votes {
                 let account_current_stake = validator_stake(&account_id);
                 self.total_voted_stake += account_current_stake;
-                if account_current_stake > 0 {
-                    self.votes.insert(account_id, account_current_stake);
-                }
+                self.votes.insert(account_id, account_current_stake);
             }
             self.check_result();
             self.last_epoch_height = cur_epoch_height;
@@ -497,7 +495,7 @@ mod tests {
         // ping will update total voted stake
         contract.ping();
         assert_eq!((contract.get_total_voted_stake().0).0, 0);
-        assert_eq!(contract.get_votes().len(), 0);
+        assert_eq!(contract.get_votes().len(), 1);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,14 @@ mod tests {
         contract.ping();
         assert_eq!((contract.get_total_voted_stake().0).0, 0);
         assert_eq!(contract.get_votes().len(), 1);
+        // validator(1) is back to validator set at epoch 3
+        validators.insert(validator(1).to_string(), NearToken::from_yoctonear(40));
+        let context = get_context_with_epoch_height(&voting_contract_id(), 3);
+        set_context_and_validators(&context, &validators);
+        // ping will update total voted stake after validator(1) is back
+        contract.ping();
+        assert_eq!((contract.get_total_voted_stake().0).0, 40);
+        assert_eq!(contract.get_votes().len(), 1);
     }
 
     #[test]

--- a/tests/test_vote.rs
+++ b/tests/test_vote.rs
@@ -493,7 +493,7 @@ async fn test_unstake_after_voting() -> Result<(), Box<dyn std::error::Error>> {
 
     let votes = owner.view(voting_contract.id(), "get_votes").await?;
     let votes = votes.json::<HashMap<AccountId, String>>()?;
-    assert_eq!(votes.len(), 1);
+    assert_eq!(votes.len(), 2);
     assert!(votes.contains_key(staking_pool_contracts[1].id()));
 
     Ok(())


### PR DESCRIPTION
Currently the kicked out validators are removed from the votes. 

We'd like to keep their votes and update the stake to `0` if they're kicked out, so their stake will counted after they rejoined the validator set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Votes with zero stake are now retained in the votes map after validator removal or stake changes.

- **Tests**
	- Updated test expectations to reflect that votes with zero stake remain in the voting contract's state.
	- Adjusted vote count assertions following voting and unstaking actions to match updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->